### PR TITLE
refactor: Replace global token price context with network-specific pr…

### DIFF
--- a/app/vote/create/challenge/[network]/page.tsx
+++ b/app/vote/create/challenge/[network]/page.tsx
@@ -16,8 +16,6 @@ import { ethers } from "ethers"
 import { 
   getSteleContractAddress,
   getGovernanceContractAddress,
-  getExplorerName,
-  getExplorerUrl
 } from "@/lib/constants"
 import GovernorABI from "@/app/abis/SteleGovernor.json"
 import { useLanguage } from "@/lib/language-context"

--- a/app/vote/create/fund/[network]/page.tsx
+++ b/app/vote/create/fund/[network]/page.tsx
@@ -17,8 +17,6 @@ import {
   getSteleFundContractAddress,
   getSteleFundGovernanceAddress,
   getSteleFundSettingAddress,
-  getExplorerName,
-  getExplorerUrl
 } from "@/lib/constants"
 import GovernorABI from "@/app/abis/SteleGovernor.json"
 import { useLanguage } from "@/lib/language-context"


### PR DESCRIPTION
…ice fetching

- Updated useFundInvestableTokenPrices and useChallengeInvestableTokenPrices hooks to utilize useUniswapBatchPrices for fetching token prices directly based on the network.
- Removed reliance on global token price context, enhancing performance and specificity.
- Adjusted price data handling to ensure accurate mapping of token prices and last updated timestamps.